### PR TITLE
Add auto-recovery engine, client risk scoring, and contract auto-invoicing (v1)

### DIFF
--- a/src/app/api/contracts/on-sign/route.ts
+++ b/src/app/api/contracts/on-sign/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from 'next/server';
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+const ALLOWED_TIERS = new Set(['advanced', 'agency']);
+
+type ContractPayload = {
+  contractId: string;
+  userId: string;
+};
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ContractPayload;
+
+    if (!body.contractId || !body.userId) {
+      return NextResponse.json({ error: 'Missing contractId or userId.' }, { status: 400 });
+    }
+
+    const supabase = createServiceRoleClient();
+
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('subscription_tier')
+      .eq('id', body.userId)
+      .single();
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 });
+    }
+
+    if (!ALLOWED_TIERS.has(profile.subscription_tier)) {
+      return NextResponse.json({ error: 'Automation requires Advanced or Agency tier.' }, { status: 403 });
+    }
+
+    const { data: contract, error: contractError } = await supabase
+      .from('contracts')
+      .select('id, user_id, client_id, title, milestone_amount, auto_invoice, signed_at')
+      .eq('id', body.contractId)
+      .eq('user_id', body.userId)
+      .single();
+
+    if (contractError) {
+      return NextResponse.json({ error: contractError.message }, { status: 500 });
+    }
+
+    if (!contract.signed_at) {
+      return NextResponse.json({ error: 'Contract is not signed.' }, { status: 400 });
+    }
+
+    if (!contract.auto_invoice) {
+      return NextResponse.json({ ok: true, created: false });
+    }
+
+    const { data: existingInvoice } = await supabase
+      .from('invoices')
+      .select('id')
+      .eq('contract_id', contract.id)
+      .eq('client_id', contract.client_id)
+      .limit(1)
+      .maybeSingle();
+
+    if (existingInvoice) {
+      return NextResponse.json({ ok: true, created: false, reason: 'Invoice already exists.' });
+    }
+
+    const signedAt = new Date(contract.signed_at);
+    const dueDate = new Date(signedAt.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { data: createdInvoice, error: invoiceError } = await supabase
+      .from('invoices')
+      .insert({
+        user_id: contract.user_id,
+        client_id: contract.client_id,
+        contract_id: contract.id,
+        invoice_number: `AUTO-${contract.id.slice(0, 8).toUpperCase()}`,
+        amount_due: contract.milestone_amount ?? 0,
+        due_date: dueDate,
+        status: 'pending',
+      })
+      .select('id, invoice_number')
+      .single();
+
+    if (invoiceError) {
+      return NextResponse.json({ error: invoiceError.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, created: true, invoice: createdInvoice });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/invoices/on-payment/route.ts
+++ b/src/app/api/invoices/on-payment/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { onInvoicePaidUpdateRisk } from '@/lib/billing/recovery';
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+function isAuthorized(req: Request) {
+  const webhookSecret = process.env.BILLING_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    return false;
+  }
+  return req.headers.get('x-webhook-secret') === webhookSecret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { invoiceId } = (await request.json()) as { invoiceId: string };
+    if (!invoiceId) {
+      return NextResponse.json({ error: 'Missing invoiceId.' }, { status: 400 });
+    }
+
+    const supabase = createServiceRoleClient();
+    const { data: invoice, error } = await supabase
+      .from('invoices')
+      .select('user_id, client_id, status')
+      .eq('id', invoiceId)
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (invoice.status !== 'paid') {
+      return NextResponse.json({ ok: true, skipped: true, reason: 'Invoice not paid.' });
+    }
+
+    const updated = await onInvoicePaidUpdateRisk({
+      userId: invoice.user_id,
+      clientId: invoice.client_id,
+    });
+
+    return NextResponse.json({ ok: true, updated });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/recovery/run/route.ts
+++ b/src/app/api/recovery/run/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { runInvoiceRecovery } from '@/lib/billing/recovery';
+
+function isAuthorized(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return false;
+  }
+
+  const header = req.headers.get('x-cron-secret') ?? req.headers.get('authorization')?.replace('Bearer ', '');
+  return header === cronSecret;
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const result = await runInvoiceRecovery();
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Recovery failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/clients/client-risk-badge.tsx
+++ b/src/components/clients/client-risk-badge.tsx
@@ -1,0 +1,27 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+const toneByLabel: Record<string, string> = {
+  Safe: 'bg-emerald-100 text-emerald-700',
+  Moderate: 'bg-amber-100 text-amber-700',
+  Risky: 'bg-red-100 text-red-700',
+};
+
+export async function ClientRiskBadge({ clientId }: { clientId: string }) {
+  const supabase = createServiceRoleClient();
+
+  const { data } = await supabase
+    .from('client_scores')
+    .select('score, label')
+    .eq('client_id', clientId)
+    .maybeSingle();
+
+  const label = data?.label ?? 'Safe';
+  const score = Number(data?.score ?? 100).toFixed(1);
+
+  return (
+    <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${toneByLabel[label] ?? toneByLabel.Safe}`}>
+      <span>{label}</span>
+      <span>{score}</span>
+    </span>
+  );
+}

--- a/src/components/invoices/recovery-status.tsx
+++ b/src/components/invoices/recovery-status.tsx
@@ -1,0 +1,40 @@
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+const stageLabel: Record<string, string> = {
+  soft: 'Soft Reminder Sent',
+  firm: 'Firm Reminder Sent',
+  final: 'Final Notice Sent',
+};
+
+const stageTone: Record<string, string> = {
+  soft: 'bg-blue-50 text-blue-700 border-blue-200',
+  firm: 'bg-amber-50 text-amber-700 border-amber-200',
+  final: 'bg-red-50 text-red-700 border-red-200',
+};
+
+export async function RecoveryStatus({ invoiceId }: { invoiceId: string }) {
+  const supabase = createServiceRoleClient();
+
+  const { data, error } = await supabase
+    .from('invoice_recovery_logs')
+    .select('stage, sent_at')
+    .eq('invoice_id', invoiceId)
+    .order('sent_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-4">
+        <p className="text-sm text-slate-600">Recovery status: No reminders sent.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded-lg border p-4 ${stageTone[data.stage] ?? 'bg-slate-50 text-slate-700 border-slate-200'}`}>
+      <p className="text-sm font-medium">{stageLabel[data.stage] ?? 'Recovery update logged'}</p>
+      <p className="mt-1 text-xs opacity-80">{new Date(data.sent_at).toLocaleString('en-US')}</p>
+    </div>
+  );
+}

--- a/src/lib/billing/recovery.ts
+++ b/src/lib/billing/recovery.ts
@@ -1,0 +1,139 @@
+import { buildRecoveryEmailTemplate, type RecoveryStage } from '@/lib/email/recovery-template';
+import { updateClientRiskScore } from '@/lib/billing/risk-score';
+import { createServiceRoleClient } from '@/lib/supabase/server';
+
+type RecoveryInvoice = {
+  id: string;
+  user_id: string;
+  client_id: string;
+  invoice_number: string;
+  amount_due: number;
+  due_date: string;
+  status: string;
+  clients: {
+    id: string;
+    name: string;
+    email: string;
+  } | null;
+};
+
+function stageForDaysOverdue(days: number): RecoveryStage | null {
+  if (days >= 14) return 'final';
+  if (days >= 7) return 'firm';
+  if (days >= 3) return 'soft';
+  return null;
+}
+
+async function sendRecoveryEmail(params: {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}) {
+  const endpoint = process.env.RECOVERY_EMAIL_ENDPOINT;
+  const apiKey = process.env.RECOVERY_EMAIL_API_KEY;
+
+  if (!endpoint || !apiKey) {
+    throw new Error('Missing recovery email provider configuration.');
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(params),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Recovery email request failed with status ${response.status}.`);
+  }
+}
+
+export async function runInvoiceRecovery() {
+  const supabase = createServiceRoleClient();
+  const today = new Date();
+
+  const { data: invoices, error } = await supabase
+    .from('invoices')
+    .select('id, user_id, client_id, invoice_number, amount_due, due_date, status, clients(id, name, email)')
+    .eq('status', 'overdue')
+    .lte('due_date', new Date(today.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString());
+
+  if (error) {
+    throw error;
+  }
+
+  const processed: Array<{ invoiceId: string; stage: RecoveryStage }> = [];
+
+  for (const invoice of (invoices ?? []) as RecoveryInvoice[]) {
+    const dueDate = new Date(invoice.due_date);
+    const daysOverdue = Math.floor((today.getTime() - dueDate.getTime()) / (1000 * 60 * 60 * 24));
+    const stage = stageForDaysOverdue(daysOverdue);
+
+    if (!stage || !invoice.clients?.email) {
+      continue;
+    }
+
+    const { data: existingLog, error: existingLogError } = await supabase
+      .from('invoice_recovery_logs')
+      .select('id')
+      .eq('invoice_id', invoice.id)
+      .eq('stage', stage)
+      .maybeSingle();
+
+    if (existingLogError) {
+      throw existingLogError;
+    }
+
+    if (existingLog) {
+      continue;
+    }
+
+    const template = buildRecoveryEmailTemplate({
+      clientName: invoice.clients.name,
+      invoiceNumber: invoice.invoice_number,
+      amountDue: Number(invoice.amount_due),
+      dueDate: dueDate.toLocaleDateString('en-US'),
+      stage,
+    });
+
+    await sendRecoveryEmail({
+      to: invoice.clients.email,
+      subject: template.subject,
+      html: template.html,
+      text: template.text,
+    });
+
+    const { error: insertError } = await supabase.from('invoice_recovery_logs').insert({
+      user_id: invoice.user_id,
+      invoice_id: invoice.id,
+      client_id: invoice.client_id,
+      stage,
+      sent_to: invoice.clients.email,
+      sent_at: new Date().toISOString(),
+    });
+
+    if (insertError) {
+      throw insertError;
+    }
+
+    await updateClientRiskScore(supabase, {
+      userId: invoice.user_id,
+      clientId: invoice.client_id,
+    });
+
+    processed.push({ invoiceId: invoice.id, stage });
+  }
+
+  return {
+    processed,
+    total: processed.length,
+  };
+}
+
+export async function onInvoicePaidUpdateRisk(params: { userId: string; clientId: string }) {
+  const supabase = createServiceRoleClient();
+  return updateClientRiskScore(supabase, params);
+}

--- a/src/lib/billing/risk-score.ts
+++ b/src/lib/billing/risk-score.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type InvoiceRecord = {
+  user_id: string;
+  client_id: string;
+  due_date: string;
+  paid_at: string | null;
+  status: string;
+};
+
+function computeScore(lateCount: number, avgDelayDays: number) {
+  const raw = 100 - lateCount * 10 - avgDelayDays * 0.5;
+  return Math.max(0, Number(raw.toFixed(2)));
+}
+
+function computeDelayDays(dueDate: string, paidAt: string | null) {
+  const due = new Date(dueDate);
+  const paid = paidAt ? new Date(paidAt) : new Date();
+  const ms = paid.getTime() - due.getTime();
+  return ms > 0 ? ms / (1000 * 60 * 60 * 24) : 0;
+}
+
+export async function updateClientRiskScore(
+  supabase: SupabaseClient,
+  params: { userId: string; clientId: string },
+) {
+  const { data: invoices, error } = await supabase
+    .from('invoices')
+    .select('user_id, client_id, due_date, paid_at, status')
+    .eq('user_id', params.userId)
+    .eq('client_id', params.clientId)
+    .in('status', ['paid', 'overdue']);
+
+  if (error) {
+    throw error;
+  }
+
+  const list = (invoices ?? []) as InvoiceRecord[];
+  let lateCount = 0;
+  let totalDelay = 0;
+
+  for (const invoice of list) {
+    const delay = computeDelayDays(invoice.due_date, invoice.paid_at);
+    if (delay > 0) {
+      lateCount += 1;
+      totalDelay += delay;
+    }
+  }
+
+  const avgDelayDays = lateCount > 0 ? Number((totalDelay / lateCount).toFixed(2)) : 0;
+  const score = computeScore(lateCount, avgDelayDays);
+
+  const { error: upsertError } = await supabase.from('client_scores').upsert(
+    {
+      user_id: params.userId,
+      client_id: params.clientId,
+      late_count: lateCount,
+      avg_delay_days: avgDelayDays,
+      score,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'client_id' },
+  );
+
+  if (upsertError) {
+    throw upsertError;
+  }
+
+  return { lateCount, avgDelayDays, score };
+}

--- a/src/lib/email/recovery-template.ts
+++ b/src/lib/email/recovery-template.ts
@@ -1,0 +1,50 @@
+export type RecoveryStage = 'soft' | 'firm' | 'final';
+
+export function buildRecoveryEmailTemplate(params: {
+  clientName: string;
+  invoiceNumber: string;
+  amountDue: number;
+  dueDate: string;
+  stage: RecoveryStage;
+}) {
+  const stageCopy: Record<RecoveryStage, { subjectPrefix: string; intro: string }> = {
+    soft: {
+      subjectPrefix: 'Friendly reminder',
+      intro: 'Just a quick reminder that this invoice is now overdue.',
+    },
+    firm: {
+      subjectPrefix: 'Action needed',
+      intro: 'Your invoice remains unpaid and now requires attention.',
+    },
+    final: {
+      subjectPrefix: 'Final notice',
+      intro: 'This is the final reminder before account escalation.',
+    },
+  };
+
+  const copy = stageCopy[params.stage];
+  const subject = `${copy.subjectPrefix}: Invoice ${params.invoiceNumber}`;
+  const html = `
+    <div style="font-family:Inter,Arial,sans-serif;max-width:620px;padding:24px;border:1px solid #e5e7eb;border-radius:12px;color:#111827">
+      <h2 style="margin:0 0 12px">Invoice ${params.invoiceNumber}</h2>
+      <p style="margin:0 0 12px">Hi ${params.clientName},</p>
+      <p style="margin:0 0 16px">${copy.intro}</p>
+      <div style="background:#f9fafb;padding:16px;border-radius:10px;margin:0 0 16px">
+        <p style="margin:0 0 8px"><strong>Amount due:</strong> $${params.amountDue.toFixed(2)}</p>
+        <p style="margin:0"><strong>Due date:</strong> ${params.dueDate}</p>
+      </div>
+      <p style="margin:0">Please submit payment as soon as possible to avoid service interruptions.</p>
+    </div>
+  `.trim();
+
+  const text = [
+    `Hi ${params.clientName},`,
+    copy.intro,
+    `Invoice: ${params.invoiceNumber}`,
+    `Amount due: $${params.amountDue.toFixed(2)}`,
+    `Due date: ${params.dueDate}`,
+    'Please submit payment as soon as possible.',
+  ].join('\n');
+
+  return { subject, html, text };
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,14 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export function createServiceRoleClient(): SupabaseClient {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase service role configuration.');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+}

--- a/supabase/migrations/202603270001_recovery_risk_contracts.sql
+++ b/supabase/migrations/202603270001_recovery_risk_contracts.sql
@@ -1,0 +1,117 @@
+create table if not exists public.invoice_recovery_logs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  invoice_id uuid not null references public.invoices(id) on delete cascade,
+  client_id uuid not null references public.clients(id) on delete cascade,
+  stage text not null check (stage in ('soft', 'firm', 'final')),
+  sent_to text not null,
+  sent_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique (invoice_id, stage)
+);
+
+create index if not exists idx_invoice_recovery_logs_invoice_id on public.invoice_recovery_logs(invoice_id);
+create index if not exists idx_invoice_recovery_logs_user_id on public.invoice_recovery_logs(user_id);
+
+create table if not exists public.client_scores (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  client_id uuid not null references public.clients(id) on delete cascade,
+  late_count integer not null default 0,
+  avg_delay_days numeric(10,2) not null default 0,
+  score numeric(10,2) not null default 100,
+  label text not null default 'Safe' check (label in ('Safe', 'Moderate', 'Risky')),
+  updated_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique (client_id)
+);
+
+create index if not exists idx_client_scores_user_id on public.client_scores(user_id);
+
+alter table public.contracts
+  add column if not exists milestone_amount numeric(12,2),
+  add column if not exists auto_invoice boolean not null default false;
+
+create or replace function public.set_client_score_label()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.label := case
+    when new.score >= 75 then 'Safe'
+    when new.score >= 45 then 'Moderate'
+    else 'Risky'
+  end;
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_set_client_score_label on public.client_scores;
+create trigger trg_set_client_score_label
+before insert or update on public.client_scores
+for each row
+execute function public.set_client_score_label();
+
+alter table public.invoice_recovery_logs enable row level security;
+alter table public.client_scores enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'invoice_recovery_logs'
+      and policyname = 'invoice_recovery_logs_select_owner'
+  ) then
+    create policy invoice_recovery_logs_select_owner on public.invoice_recovery_logs
+    for select
+    using (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'invoice_recovery_logs'
+      and policyname = 'invoice_recovery_logs_insert_owner'
+  ) then
+    create policy invoice_recovery_logs_insert_owner on public.invoice_recovery_logs
+    for insert
+    with check (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'client_scores'
+      and policyname = 'client_scores_select_owner'
+  ) then
+    create policy client_scores_select_owner on public.client_scores
+    for select
+    using (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'client_scores'
+      and policyname = 'client_scores_insert_owner'
+  ) then
+    create policy client_scores_insert_owner on public.client_scores
+    for insert
+    with check (auth.uid() = user_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'client_scores'
+      and policyname = 'client_scores_update_owner'
+  ) then
+    create policy client_scores_update_owner on public.client_scores
+    for update
+    using (auth.uid() = user_id)
+    with check (auth.uid() = user_id);
+  end if;
+end
+$$;


### PR DESCRIPTION
### Motivation
- Automate overdue invoice recovery with staged reminders, introduce client risk scoring to surface payment risk, and enable contract-driven invoice automation for eligible subscription tiers.

### Description
- Add Supabase migration to create `invoice_recovery_logs` and `client_scores`, extend `contracts` with `milestone_amount` and `auto_invoice`, add RLS policies and a trigger `set_client_score_label` (`supabase/migrations/202603270001_recovery_risk_contracts.sql`).
- Implement recovery engine, email template, and risk-score updater in `src/lib/billing/recovery.ts`, `src/lib/email/recovery-template.ts`, and `src/lib/billing/risk-score.ts` with staged escalation at 3/7/14 days and scoring formula `score = 100 - (late_count * 10) - (avg_delay_days * 0.5)`.
- Add service-role Supabase helper and three API routes: `POST /api/recovery/run` (`src/app/api/recovery/run/route.ts`) for cron/manual runs, `POST /api/contracts/on-sign` (`src/app/api/contracts/on-sign/route.ts`) to auto-create invoices when contracts are signed (gated to `advanced`/`agency` tiers), and `POST /api/invoices/on-payment` (`src/app/api/invoices/on-payment/route.ts`) to refresh risk on payment webhooks.
- Include minimal UI components to surface status: invoice recovery status (`src/components/invoices/recovery-status.tsx`) and client risk badge (`src/components/clients/client-risk-badge.tsx`).

### Testing
- Ran `git diff --check --cached` which returned no issues and passed. 
- Ran `git status --short` to validate staged changes which succeeded. 
- Created commit successfully adding the migration and source files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6098b19808325b716915724650c14)